### PR TITLE
Adding github actions for protbufs

### DIFF
--- a/.github/auto_assign.yaml
+++ b/.github/auto_assign.yaml
@@ -1,0 +1,1 @@
+addAssignees: author

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  commit-message:
+    prefix: "chore(deps)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"

--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,0 +1,10 @@
+protos:
+  - '**.protos'
+
+dependencies:
+  - '**/buf.lock'
+
+github_actions:
+  - '.github/workflows/**'
+  - '.github/labeler.yaml'
+  - '.github/triage-labeler.yaml'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+<!-- List changes here -->
+
+### Motivation
+
+<!-- Describe why these changes should happen, e.g. "Currently we...", or "This is needed because..." -->
+
+### Future Work
+<!--
+* Out of scope non-goals for this PR
+* These should be links to tickets. If the tickets do not exist, make them.
+-->
+

--- a/.github/triage-labeler.yaml
+++ b/.github/triage-labeler.yaml
@@ -1,0 +1,2 @@
+needs-triage:
+  - '.*'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,36 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+
+jobs:
+  markdown-lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: xt0rted/markdownlint-problem-matcher@v2
+      - uses: DavidAnson/markdownlint-cli2-action@v9
+        with:
+          globs: "**/*.md"
+
+  notify:
+    runs-on: ubuntu-latest
+    if: ${{always()}} && ${{failure()}} && ${{ github.event_name }} == 'push'
+    needs:
+      - markdown-lint
+    steps:
+      - name: Notify Discord on failure
+        uses: sarisia/actions-status-discord@v1
+        with:
+          username: "Github Actions"
+          status: Failure
+          nodetail: true
+          title: "Workflow: ${{ github.workflow }}"
+          url: ${{ github.repositoryUrl }}/actions/runs/${{ github.run_id }}
+          description: |
+            [@${{ github.actor }}](${{ github.server_url }}/${{ github.actor }}] was the last one to touch ${{ github.repository }}, is all I'm saying...
+          avatar_url: "https://media0.giphy.com/media/oe33xf3B50fsc/200.gif"
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -1,0 +1,17 @@
+name: issues
+
+on:
+  issues:
+    types:
+      - opened
+      - transferred
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: github/issue-labeler@v2.6
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: .github/triage-labeler.yaml
+        enable-versioned-regex: 0

--- a/.github/workflows/pr-assign.yaml
+++ b/.github/workflows/pr-assign.yaml
@@ -1,0 +1,15 @@
+name: pr-assign
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.2.4
+        with:
+          configuration-path: '.github/auto_assign.yaml'

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,0 +1,37 @@
+name: pr
+
+on:
+  pull_request:
+
+jobs:
+  size-label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: pascalgn/size-label-action@v0.4.3
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          IGNORED: "Cargo.lock"
+          INPUT_SIZES: >
+            {
+              "0": "XS",
+              "30": "S",
+              "100": "M",
+              "250": "L",
+              "500": "XL",
+              "1000": "XXL",
+              "1500": "OHLAWDHECOMIN"
+            }
+
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        configuration-path: ".github/labeler.yaml"

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,14 @@
+{
+  // Disable some built-in rules
+  "config": {
+    "line-length": false,
+    "no-duplicate-header": {
+        // Allow multiple "Added" sections in the changelog
+        "siblings_only": true
+    }
+  },
+
+  // Define glob expressions to use (only valid at root)
+  "globs": ["**/*.md"],
+  "ignores": [".github/pull_request_template.md"]
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # protobufs
+
 MobileCoin Protocol Buffers Definitions (Future)


### PR DESCRIPTION
Adds a chunk of the github actions files.
will add the buf ones later as those tools fail when there is a lack of `proto` files. See https://github.com/nick-mobilecoin/enclave-proto/pull/6 and https://github.com/nick-mobilecoin/enclave-proto/pull/7 for what's coming with those actions

